### PR TITLE
fix(ci): Remove flaky fault equivalence test

### DIFF
--- a/tests/equivalence/test_fault_equivalence.py
+++ b/tests/equivalence/test_fault_equivalence.py
@@ -380,11 +380,3 @@ def test_idempotent_non_normal_weight():
     nm = NoiseModel.weighted_edge_flip_noise(d, 1, 2, 3)
 
     assert is_fault_equivalence(nm, nm, quiet=False)
-
-
-def test_non_normal_weight_negative():
-    d = from_pyzx(generate.clifford(5, 10))
-    nm1 = NoiseModel.weighted_edge_flip_noise(d, 1, 2, 1)
-    nm2 = NoiseModel.weighted_edge_flip_noise(d, 1, 2, 3)
-
-    assert not is_fault_equivalence(nm1, nm2, quiet=False)


### PR DESCRIPTION
Removes a flaky fault equivalence test (that tested one diagram is not fault equivalent to itself under two different noise models), since the test generator could generate diagrams that were tolerant to the changes made to the noise models. For example, seed `1142253153232752205` with `generate.clifford(1, 1)` results in
<img width="701" height="343" alt="image" src="https://github.com/user-attachments/assets/a6c9998e-8b5e-4af5-9543-e971a7017efb" />
which can easily be shown to be independent of changes to the `Z` weight (for every location in the diagram where a `Z` fault could be located, there is at least one other location where an `X` fault is equivalent to it).