### PR TITLE
chore: Default all dev dependency groups

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           enable-cache: 'true'
 
       - name: Install the project
-        run: uv sync --locked --all-extras --group all
+        run: uv sync --locked --all-extras
 
       - name: Run tests
         run: uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ dependencies = [
 ]
 
 [dependency-groups]
-all = [
+dev = [
     { include-group = "bench" },
-    { include-group = "dev" },
+    { include-group = "lint" },
     { include-group = "test" },
 ]
 
@@ -29,7 +29,7 @@ bench = [
     "pyinstrument>=5.1.1",
 ]
 
-dev = [
+lint = [
     "pre-commit>=4.5.1",
     "ruff==0.14.9", # Pinned to ensure everyone uses the same rules
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1377,16 +1377,16 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
-all = [
+bench = [
+    { name = "pyinstrument" },
+]
+dev = [
     { name = "pre-commit" },
     { name = "pyinstrument" },
     { name = "pytest" },
     { name = "ruff" },
 ]
-bench = [
-    { name = "pyinstrument" },
-]
-dev = [
+lint = [
     { name = "pre-commit" },
     { name = "ruff" },
 ]
@@ -1408,14 +1408,14 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-all = [
+bench = [{ name = "pyinstrument", specifier = ">=5.1.1" }]
+dev = [
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pyinstrument", specifier = ">=5.1.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "ruff", specifier = "==0.14.9" },
 ]
-bench = [{ name = "pyinstrument", specifier = ">=5.1.1" }]
-dev = [
+lint = [
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "ruff", specifier = "==0.14.9" },
 ]


### PR DESCRIPTION
Makes installing all dependency groups the default. This was causing issues when commands not including all groups desynced your environment, to where you had to reinstall a bunch of packages to run other commands in a package-tug-of-war.