### PR TITLE
fix: Circuit builder does not queue faults for 2 qubit gates

### DIFF
--- a/src/paritea/generate/circuit_builder.py
+++ b/src/paritea/generate/circuit_builder.py
@@ -1,6 +1,7 @@
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass, field
+from enum import StrEnum
 from fractions import Fraction
 
 from paritea import Pauli, PauliString
@@ -37,6 +38,12 @@ class NoiseModelBuilder[CostT]:
             for p, cost in zip((Pauli.X, Pauli.Z, Pauli.Y), self.reset_cost):
                 if cost is not None:
                     yield {q: p}, cost
+
+
+class PauliBasis(StrEnum):
+    X = "X"
+    Y = "Y"
+    Z = "Z"
 
 
 @dataclass(init=False)
@@ -116,22 +123,42 @@ class CircuitBuilder[CostT]:
 
         return new_nodes
 
-    def append_measure(self, qs: Iterable[int], n_type: NodeType) -> list[int]:
+    def append_measure(self, qs: Iterable[int], basis: PauliBasis) -> list[int]:
+        """Appends a measurement in the given basis postselected to the +1 eigenstate of
+        the basis."""
         for prot, cost in self._noise_model_builder.for_measure(qs):
             self._queue_for_edge_replacement(prot, cost)
-        return self._append_single_qubit(qs, n_type)
+
+        match basis:
+            case PauliBasis.X:
+                return self._append_single_qubit(qs, NodeType.Z)
+            case PauliBasis.Y:
+                return self._append_single_qubit(qs, NodeType.Z, phase=Fraction(-1, 2))
+            case PauliBasis.Z:
+                return self._append_single_qubit(qs, NodeType.X)
+            case _:
+                raise NotImplementedError(f"Unknown basis: {basis}")
 
     def append_measure_comp(self, qs: Iterable[int]) -> list[int]:
-        return self.append_measure(qs, NodeType.X)
+        return self.append_measure(qs, PauliBasis.Z)
 
-    def append_reset(self, qs: Iterable[int], n_type: NodeType) -> list[int]:
-        nodes = self._append_single_qubit(qs, n_type, connect=False)
+    def append_reset(self, qs: Iterable[int], basis: PauliBasis) -> list[int]:
+        """Appends a reset into the +1 eigenstate of the given basis."""
+        match basis:
+            case PauliBasis.X:
+                nodes = self._append_single_qubit(qs, NodeType.Z, connect=False)
+            case PauliBasis.Y:
+                nodes = self._append_single_qubit(qs, NodeType.Z, phase=Fraction(1, 2))
+            case PauliBasis.Z:
+                nodes = self._append_single_qubit(qs, NodeType.X, connect=False)
+            case _:
+                raise NotImplementedError(f"Unknown basis: {basis}")
         for prot, cost in self._noise_model_builder.for_reset(qs):
             self._queue_for_edge_replacement(prot, cost)
         return nodes
 
     def append_reset_zero(self, qs: Iterable[int]) -> list[int]:
-        return self.append_reset(qs, NodeType.X)
+        return self.append_reset(qs, PauliBasis.Z)
 
     def append_x(self, qs: Iterable[int]) -> list[int]:
         nodes = self._append_single_qubit(qs, NodeType.X)

--- a/src/paritea/generate/circuit_builder.py
+++ b/src/paritea/generate/circuit_builder.py
@@ -111,6 +111,9 @@ class CircuitBuilder[CostT]:
             new_nodes.append(c_node)
             new_nodes.append(t_node)
 
+        for prot, cost in self._noise_model_builder.for_two_q(cts):
+            self._queue_for_edge_replacement(prot, cost)
+
         return new_nodes
 
     def append_measure(self, qs: Iterable[int], n_type: NodeType) -> list[int]:

--- a/src/paritea/generate/circuit_builder.py
+++ b/src/paritea/generate/circuit_builder.py
@@ -140,6 +140,7 @@ class CircuitBuilder[CostT]:
                 raise NotImplementedError(f"Unknown basis: {basis}")
 
     def append_measure_comp(self, qs: Iterable[int]) -> list[int]:
+        """Appends a measurement in the computational basis postselected to |0>."""
         return self.append_measure(qs, PauliBasis.Z)
 
     def append_reset(self, qs: Iterable[int], basis: PauliBasis) -> list[int]:
@@ -158,6 +159,7 @@ class CircuitBuilder[CostT]:
         return nodes
 
     def append_reset_zero(self, qs: Iterable[int]) -> list[int]:
+        """Appends a reset into |0>."""
         return self.append_reset(qs, PauliBasis.Z)
 
     def append_x(self, qs: Iterable[int]) -> list[int]:


### PR DESCRIPTION
The circuit builder forgot to queue faults for 2 qubit gates (currently the CNOT gate).

Additionally, as a driveby improvement, the API for appending measurements and resets is improved.